### PR TITLE
Switch to SpringFramework 4.0.0.RC2 to restore the project

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 	<version>1.0.0-SNAPSHOT</version>
 
 	<properties>
-		<org.springframework-version>4.0.0.BUILD-SNAPSHOT</org.springframework-version>
+		<org.springframework-version>4.0.0.RC2</org.springframework-version>
 	</properties>
 
 	<dependencies>
@@ -101,27 +101,27 @@
 			<scope>test</scope>
 		</dependency>
 
-		
+
 	</dependencies>
 
 	<repositories>
 		<repository>
-			<id>spring-snapshots</id>
-			<url>http://repo.springsource.org/snapshot</url>
-			<snapshots><enabled>true</enabled></snapshots>
-			<releases><enabled>false</enabled></releases>
-		</repository>
-		<repository>
 			<id>spring-milestones</id>
-			<url>http://repo.springsource.org/libs-milestone</url>
-			<snapshots><enabled>false</enabled></snapshots>
-			<releases><enabled>true</enabled></releases>
+			<name>Spring Milestones</name>
+			<url>http://repo.spring.io/milestone</url>
+			<snapshots>
+				<enabled>false</enabled>
+			</snapshots>
 		</repository>
 		<repository>
 			<id>tomcat-snapshots</id>
 			<url>https://repository.apache.org/content/repositories/snapshots</url>
-			<snapshots><enabled>true</enabled></snapshots>
-			<releases><enabled>false</enabled></releases>
+			<snapshots>
+				<enabled>true</enabled>
+			</snapshots>
+			<releases>
+				<enabled>false</enabled>
+			</releases>
 		</repository>
 		<repository>
 			<id>java-net</id>


### PR DESCRIPTION
I've updated the pom file to use Spring Framework 4.0.0.RC2 which restores this project to a compilable and runnable state out of the box. I've confirmed this with mvn jetty:run and by verifying the localhost server functionality.
